### PR TITLE
PADV-175 - Make site-aware redirects for the purchase workflow.

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -960,6 +960,10 @@ class HandleConsentEnrollment(View):
             lms_root_url,
             '/courses/{course_id}/courseware',
         )
+        LMS_START_PREMIUM_COURSE_FLOW_URL = urljoin(
+            lms_root_url,
+            '/verify_student/start-flow/{course_id}/',
+        )
         enrollment_course_mode = request.GET.get('course_mode')
         enterprise_catalog_uuid = request.GET.get('catalog')
 
@@ -1352,11 +1356,16 @@ class CourseEnrollmentView(NonAtomicView):
         """
         Process a submitted track selection form for the enterprise.
         """
-        # We need to override this constant here, because it's calculated at load time and there's no
+        # We need to override these constants here, because they are calculated at load time and there's no
         # Site context at load time.
+        lms_root_url = get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
         LMS_COURSEWARE_URL = urljoin(
-            get_configuration_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            lms_root_url,
             '/courses/{course_id}/courseware',
+        )
+        LMS_START_PREMIUM_COURSE_FLOW_URL = urljoin(
+            lms_root_url,
+            '/verify_student/start-flow/{course_id}/',
         )
         enterprise_customer, course, course_run, course_modes = self.get_base_details(
             request, enterprise_uuid, course_id


### PR DESCRIPTION
## Description:

This PR adds the capability to make a site-aware redirect when the course purchase workflow is initiated. This is required to redirect the user to the appropriate ecommerce site.

## Configuration:

1. Ecommerce and Discovery partners must match.
2. The e-commerce site must be configured to the appropriate LMS site.
3. The ecommerce course must be created on the same ecommerce site that you intend to use.
4. LMS site should be configured as follows:
`{"COURSE_CATALOG_API_URL":"http://<discovery-url>:18381/api/v1/",
"ECOMMERCE_API_URL":"http://<ecommerce-url>:18130",
"SESSION_COOKIE_DOMAIN":"<principal-domain>",
"LMS_ROOT_URL":"<lms-url>:18000",
"ECOMMERCE_PUBLIC_URL_ROOT":"http://<ecommerce-url>:18130"}`

## Testing:

1. Enable [Enterprise](https://open-edx-enterprise-service-documentation.readthedocs.io/en/latest/getting_started.html).
2. Create a new paid course. (Verified seat)
3. Synchronize course metadata in Discovery https://edx-discovery.readthedocs.io/en/latest/introduction.html#data-loading.
4. Go to an Enterprise enrollment URL, e.g.` <LMS-HOST>/enterprise/<enterprise-customer-id>/course/<course-id>/enroll/`
5. Select a verified seat.
6. You should be redirected to the desired ecommerce site.

## Reviewers:

- [x] @Jacatove 
- [x] @anfbermudezme  