### PR TITLE
PADV-549 - Disable data sharing consent.

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -85,6 +85,11 @@ from enterprise.utils import (
 from integrated_channels.cornerstone.utils import create_cornerstone_learner_data
 
 try:
+    from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+except ImportError:
+    configuration_helpers = None
+
+try:
     from openedx.core.djangoapps.catalog.utils import get_localized_price_text
 except ImportError:
     get_localized_price_text = None
@@ -1704,11 +1709,17 @@ class CourseEnrollmentView(NonAtomicView):
                 data_sharing_consent
             )
 
+        # If enterprise-catalog is not enabled it is necessary disable data sharing consent
+        # for enterprise customers.
         user_consent_needed = get_data_sharing_consent(
             enterprise_customer_user.username,
             enterprise_customer.uuid,
-            course_id=course_id
-        ).consent_required()
+            course_id=course_id,
+        ).consent_required() if not configuration_helpers.get_value(
+            'DISABLE_DATA_SHARING_CONSENT',
+            False,
+        ) else False
+
         if not selected_course_mode.get('premium') and not user_consent_needed:
             # For the audit course modes (audit, honor), where DSC is not
             # required, enroll the learner directly through enrollment API


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-549

## Description

After the enterprise migration https://agile-jira.pearson.com/browse/PADV-489, it was found that when an enterprise customer has data sharing consent enabled and enterprise-catalog is not enabled, the URL where a new enterprise enrollment is directed leads nowhere. Therefore, in this PR the option to redirect to the enterprise-catalog is disabled and it must be redirected to the expected URL, behavior that we currently have in Juniper, through a site configuration called `DISABLE_DATA_SHARING_CONSENT`.

## Changes Made

- [x] Add feature flag to disable data sharing consent in olive.
