### PR TITLE
Remove sidebar in enrollment page.

### DIFF
--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -8,12 +8,8 @@
 
 {% block contents %}
   <div class="enterprise-container">
-    <div class="row no-gutters">
-      <div class="col-3">
-        {% include "enterprise/_enterprise_customer_sidebar.html" %}
-      </div>
-      <div class="col-7 border-left">
-
+    <div class="row">
+      <div class="col-8">
         {# Display success, error, warning or info messages #}
         {% alert_messages messages %}
 
@@ -77,20 +73,6 @@
 
                 <label for="radio{{ forloop.counter0 }}">
                   <strong class="title">{{ course_mode.title }}</strong>
-                  <span class="price">
-                    {{ price_text }}:
-                    {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
-                      {% if hide_course_original_price %}
-                        {{ course_mode.final_price }}
-                      {% else %}
-                        <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
-                        <div>{{discount_text|safe }}</div>
-                      {% endif %}
-                    {% else %}
-                      {{ course_mode.original_price }}
-                    {% endif %}
-                  </span>
-                  <span class="description">{{ course_mode.description }}</span>
                 </label>
               </div>
               {% endfor %}

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -9,7 +9,7 @@
 {% block contents %}
   <div class="enterprise-container">
     <div class="row">
-      <div class="col-8">
+      <div class="col-8" style="margin: auto;">
         {# Display success, error, warning or info messages #}
         {% alert_messages messages %}
 


### PR DESCRIPTION
## Description

This PR removed the unwanted sidebar on the business registration page and also the price display.

![Selection_016](https://github.com/Pearson-Advance/edx-enterprise/assets/30726391/7ec5cc71-4a2e-4d6d-96a9-7a1379534e1d)

## Changes made

- [x] remove sidebar and price from `enterprise_course_enrollment_page`.

## How to test

- Run openedx service.
- Set enterprise customer
- Go to the enterprise enrollment page  `{LMS_SITE}/enterprise/{ENTERPRISE_CUSTOMER_UUID}/course/{course-key}/enroll`
- See that the sidebar and price are removed.

