### PR TITLE
PADV-647 - Remove sidebar and price details from the enrollment page.

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.57.1.post3"
+__version__ = "3.57.1.post4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -9,10 +9,7 @@
 {% block contents %}
   <div class="enterprise-container">
     <div class="row no-gutters">
-      <div class="col-3">
-        {% include "enterprise/_enterprise_customer_sidebar.html" %}
-      </div>
-      <div class="col-7 border-left">
+      <div class="col-8">
 
         {# Display success, error, warning or info messages #}
         {% alert_messages messages %}
@@ -77,20 +74,6 @@
 
                 <label for="radio{{ forloop.counter0 }}">
                   <strong class="title">{{ course_mode.title }}</strong>
-                  <span class="price">
-                    {{ price_text }}:
-                    {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
-                      {% if hide_course_original_price %}
-                        {{ course_mode.final_price }}
-                      {% else %}
-                        <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
-                        <div>{{discount_text|safe }}</div>
-                      {% endif %}
-                    {% else %}
-                      {{ course_mode.original_price }}
-                    {% endif %}
-                  </span>
-                  <span class="description">{{ course_mode.description }}</span>
                 </label>
               </div>
               {% endfor %}

--- a/enterprise/templates/enterprise/enterprise_error_page_with_messages.html
+++ b/enterprise/templates/enterprise/enterprise_error_page_with_messages.html
@@ -5,11 +5,7 @@
 {% block contents %}
   <div class="enterprise-container">
     <div class="row">
-      <div class="col-3">
-        {% include "enterprise/_enterprise_customer_sidebar.html" %}
-      </div>
-
-      <div class="col-7 border-left">
+      <div class="col-8">
         {# Display success, error, warning or info messages #}
         {% alert_messages messages %}
       </div>

--- a/enterprise/templates/enterprise/grant_data_sharing_permissions.html
+++ b/enterprise/templates/enterprise/grant_data_sharing_permissions.html
@@ -24,10 +24,7 @@
 {% block contents %}
   <div class="enterprise-container">
       <div class="row">
-          <div class="col-3">
-              {% include "enterprise/_enterprise_customer_sidebar.html" %}
-          </div>
-          <div class="col-7 border-left">
+          <div class="col-8">
               {% include "enterprise/_data_sharing_policy.html" %}
           </div>
       </div>

--- a/enterprise/templates/enterprise/templatetags/course_modal.html
+++ b/enterprise/templates/enterprise/templatetags/course_modal.html
@@ -23,30 +23,6 @@
         </header>
         <div class="details">
           <ul class="details-list">
-            {% if premium_modes|length > 0 %}
-              {% with course_mode=premium_modes.0 %}
-                {% if course_mode.original_price %}
-                  <li>
-                    <div class="detail-container">
-                      <div class="detail-title-container">
-                        <span class="icon fa fa-tag" aria-hidden="true"></span>
-                        <span class="title">{{ price_text }}</span>
-                      </div>
-                      <div class="detail-value-container">
-                        <span class="text">
-                          {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
-                            <strike>{{ course_mode.original_price }}</strike>
-                            <span class="discount">{{ course_mode.final_price }}</span>
-                          {% else %}
-                            {{ course_mode.original_price }}
-                          {% endif %}
-                        </span>
-                      </div>
-                    </div>
-                  </li>
-                {% endif %}
-              {% endwith %}
-            {% endif %}
             {% if course_level_type %}
               <li>
                 <div class="detail-container">


### PR DESCRIPTION
## Rationale:

Since the courses offered through Enterprise have already been paid for by the Enterprise customer, it is necessary to remove any legends about the price of the course so that the student is not confused.

## Description:

This PR removes some elements and information about the course price in the enrollment page.

## Screenshots:

![image](https://github.com/Pearson-Advance/edx-enterprise/assets/17520199/770424da-6665-4860-8b9a-232ed2438cc5)

## Configuration:

1. Configure Discovery: https://edx-discovery.readthedocs.io/en/latest/quickstart.html#quickstart
2. Configure ecommerce: https://edx-ecommerce.readthedocs.io/en/latest/create_products/create_course_seats.html
3. Ecommerce and Discovery partners must match.
4. The e-commerce site must be configured to the appropriate LMS site.
5. The ecommerce course must be created on the same ecommerce site that you intend to use.
6. LMS site should be configured as follows:
`{"COURSE_CATALOG_API_URL":"http://<discovery-url>:18381/api/v1/",
"ECOMMERCE_API_URL":"http://<ecommerce-url>:18130",
"SESSION_COOKIE_DOMAIN":"<principal-domain>",
"LMS_ROOT_URL":"<lms-url>:18000",
"ECOMMERCE_PUBLIC_URL_ROOT":"http://<ecommerce-url>:18130"}`

## How to test:

1. Enable [Enterprise](https://open-edx-enterprise-service-documentation.readthedocs.io/en/latest/getting_started.html).
2. Create a new paid course. (Verified seat)
3. Synchronize course metadata in Discovery https://edx-discovery.readthedocs.io/en/latest/introduction.html#data-loading.
4. Go to an Enterprise enrollment URL, e.g.` <LMS-HOST>/enterprise/<enterprise-customer-id>/course/<course-id>/enroll/`
7. Check that there is not pricing legend in the page.

## Notes:

Previous PR: https://github.com/Pearson-Advance/edx-enterprise/pull/1/
PR #10 has been closed in favor of this PR.

## Reviewers:

- [ ] @Jacatove 
- [ ] @anfbermudezme 
