### PR TITLE
PADV-735 - Allow catalogue query values to be send as query params.

### DIFF
--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -104,6 +104,12 @@ class CourseCatalogApiClient(UserAPIClient):
         Return results from the discovery service's search/all endpoint.
         """
         api_url = self.get_api_url(self.SEARCH_ALL_ENDPOINT)
+
+        # This change allows the key list to be sent as query parameters.
+        # This is a temporary change to support catalogues with specific courses.
+        if content_filter_query.get('key'):
+            query_params['key'] = content_filter_query.get('key')
+
         response = self.client.post(api_url, data=content_filter_query, params=query_params)
         response.raise_for_status()
         response = response.json()


### PR DESCRIPTION
## Description:

This change allows to convert catalogue query "key" values into URL query params. The Catalogue query values are sent within the body of the request, but for some reason, when sending multiple key values, the Discovery API does not return the required data.

## NOTE:

This PR needs to be merged without review as we need this changes as soon as we can.

