### PR TITLE
feat: adding no-id-professional mode to enrollment api view serializer

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -920,7 +920,8 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
         choices=(
             ('audit', 'audit'),
             ('verified', 'verified'),
-            ('professional', 'professional')
+            ('professional', 'professional'),
+            ('no-id-professional', 'no-id-professional')
         ),
         required=True,
         write_only=True,


### PR DESCRIPTION
## Description:

This PR aims to add the no-id-professional course mode to the enterprise course enrollment serializer. VUE uses this course mode primarily and enterprise customers need to be able to enroll users in no-id-professional, previously the enrollment API didn't allow this mode.

## Configuration:

1. Configure Discovery: https://edx-discovery.readthedocs.io/en/latest/quickstart.html#quickstart
2. Configure ecommerce: https://edx-ecommerce.readthedocs.io/en/latest/create_products/create_course_seats.html
3. Ecommerce and Discovery partners must match.
4. The e-commerce site must be configured to the appropriate LMS site.
5. The ecommerce course must be created on the same ecommerce site that you intend to use.
6. LMS site should be configured as follows:
`{"COURSE_CATALOG_API_URL":"http://<discovery-url>:18381/api/v1/",
"ECOMMERCE_API_URL":"http://<ecommerce-url>:18130",
"SESSION_COOKIE_DOMAIN":"<principal-domain>",
"LMS_ROOT_URL":"<lms-url>:18000",
"ECOMMERCE_PUBLIC_URL_ROOT":"http://<ecommerce-url>:18130"}`

## How to test:

1. Enable [Enterprise](https://open-edx-enterprise-service-documentation.readthedocs.io/en/latest/getting_started.html).
2. Create a new paid course. (Professional seat with no id required)
3. Add course to enterprise customer catalog.
4. Synchronize course metadata in Discovery https://edx-discovery.readthedocs.io/en/latest/introduction.html#data-loading.
5. POST to the /enterprise/api/v1/enterprise-customer/{{ENTERPRISE_CUSTOMER_UUID}}/course_enrollments/ endpoint with the following body:
```
[
    {
        "user_email": "enterpriseuser1@example.com",
        "course_run_id": "course-v1:EnterpriseTest+1+1",
        "course_mode": "no-id-professional"
    }
]
```
6. The result should be the following:
```
[{"detail":"success"}]
```

## Reviewers:

- [ ] @Serafin-dev 
