### PR TITLE
PADV 2561 - Add site aware capabilities to enterprise LMS TPA API requests

### DIFF
--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -20,9 +20,10 @@ from enterprise.constants import COURSE_MODE_SORT_ORDER, EXCLUDED_COURSE_MODES
 
 try:
     from openedx.core.djangoapps.embargo import api as embargo_api
+    from openedx.core.djangoapps.site_configuration.helpers import get_value
 except ImportError:
     embargo_api = None
-
+    get_value = None
 
 LOGGER = logging.getLogger(__name__)
 
@@ -307,7 +308,12 @@ class ThirdPartyAuthApiClient(UserAPIClient):
     The API client to make calls to the Third Party Auth API.
     """
 
-    API_BASE_URL = urljoin(f"{settings.LMS_INTERNAL_ROOT_URL}/", "api/third_party_auth/v0/")
+    def __init__(self, user, expires_in=settings.OAUTH_ID_TOKEN_EXPIRATION):
+        if get_value:
+            self.API_BASE_URL = urljoin(
+                f"{get_value('LMS_INTERNAL_ROOT_URL', settings.LMS_INTERNAL_ROOT_URL)}/", "api/third_party_auth/v0/",
+            )
+        super().__init__(user, expires_in)
 
     @UserAPIClient.refresh_token
     def get_remote_id(self, identity_provider, username):

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -7,13 +7,16 @@ from functools import wraps
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from crum import get_current_request, set_current_request
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 from django.contrib import auth
+from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.utils import timezone
 
 from enterprise.utils import get_enterprise_uuids_for_user_and_course
+from enterprise.models import EnterpriseCustomer
 from integrated_channels.integrated_channel.constants import TASK_LOCK_EXPIRY_SECONDS
 from integrated_channels.integrated_channel.management.commands import (
     INTEGRATED_CHANNEL_CHOICES,
@@ -89,6 +92,38 @@ def _log_batch_task_finish(task_name, channel_code, job_user_id,
         ))
 
 
+def set_enterprise_customer_site_to_request(enterprise_customer):
+    """
+    Set the site of the current request to the site of the given enterprise customer.
+
+    This is necessary since during the transmission of learner data, the request's site is used to determine
+    the domain for LMS API calls. This ensures that the correct site configurations are used when making requests 
+    to the LMS.
+
+    We decided to rely on an external plugin to set the request context for tasks, if there's no request context,
+    then the site will be None and the task will use the default Django settings. In our case we'd use pearson-core.
+    """
+
+    request = get_current_request()
+    if not request:
+        LOGGER.warning('No current request found in context. Install "pearson-core" to set requests contexts to tasks.')
+        return
+
+    if request.site:
+        LOGGER.info('Current request already has a site set: %s', request.site.domain)
+        return
+
+    site = enterprise_customer.site
+    request.site = site
+
+    set_current_request(request)
+    LOGGER.info(
+        'Current request site set to %s EnterpriseCustomer\'s site with domain: %s',
+        enterprise_customer.name,
+        site.domain,
+    )
+
+
 @shared_task
 @set_code_owner_attribute
 @locked(expiry_seconds=TASK_LOCK_EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
@@ -139,6 +174,8 @@ def transmit_learner_data(username, channel_code, channel_pk):
     api_user = User.objects.get(username=username)
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
     _log_batch_task_start('transmit_learner_data', channel_code, api_user.id, integrated_channel)
+
+    set_enterprise_customer_site_to_request(integrated_channel.enterprise_customer)
 
     # Note: learner data transmission code paths don't raise any uncaught exception,
     # so we don't need a broad try-except block here.
@@ -236,6 +273,8 @@ def transmit_single_learner_data(username, course_run_id):
                 'transmit_single_learner_data started.'
             ))
 
+            set_enterprise_customer_site_to_request(integrated_channel.enterprise_customer)
+
             integrated_channel.transmit_single_learner_data(
                 learner_to_transmit=user,
                 course_run_id=course_run_id,
@@ -298,6 +337,8 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
                 subsection_id=subsection_id
             )
 
+            set_enterprise_customer_site_to_request(integrated_channel.enterprise_customer)
+
             duration = time.time() - start
             LOGGER.info(generate_formatted_log(
                 None,
@@ -328,6 +369,8 @@ def transmit_subsection_learner_data(job_username, channel_code, channel_pk):
     api_user = User.objects.get(username=job_username)
     integrated_channel = INTEGRATED_CHANNEL_CHOICES[channel_code].objects.get(pk=channel_pk)
     _log_batch_task_start('transmit_subsection_learner_data', channel_code, api_user.id, integrated_channel)
+
+    set_enterprise_customer_site_to_request(integrated_channel.enterprise_customer)
 
     # Exceptions during transmission are caught and saved within the audit so no need to try/catch here
     integrated_channel.transmit_subsection_learner_data(api_user)


### PR DESCRIPTION
## Description:

This PR aims to fix an issue with enterprise TPA api client in which the API_BASE_URL is retrieved from the setting `LMS_INTERNAL_ROOT_URL` and which causes the third_party_app in the platform to handle all request with idps only inside the site from the API_BASE_URL. For example, if  integrated channels wants to transmit learner data, it would ask the tpa api to get the external id from the idp associated with the customer, however, because idps are associated to a particular site, if this site doesn't matches the one on BASE_API_URL, then the api will return no results, causing the learner transmission to fail.

## How to test:

- Setup devstack with enterprise, enterprise catalog service and workers.
- Create an enteprise customer and create an integrated channel plugin config associated to the customer created.
- Create a SAML idp and associate it to the enterprise customer.
- Perform the steps to transmit learner data.
- The request to LMS TPA API should be made with the value of the site configuration `LMS_INTERNAL_ROOT_URL` of the site associated with yhe enterprise customer.

## Reviewers:

- [ ] @Squirrel18