### PR TITLE
PADV 2570 - Automatically create data sharing consent records for enterprise enrollments

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1735,6 +1735,16 @@ class CourseEnrollmentView(NonAtomicView):
                     dict(user=self.user_id, message=error_message)
                 )
             if succeeded:
+                # We've dediced to automatically grant consent if the enterprise has
+                # set the enforce_data_sharing_consent config to EXTERNALLY_MANAGED
+                # since the user has already gone through the consent flow outside
+                # of the platform. We do this during the course enrollment process
+                # insde this course enrollment view. This way we can link the consent
+                # to the enterprise customer, course and user.
+                if enterprise_customer.enforce_data_sharing_consent == enterprise_customer.EXTERNALLY_MANAGED:
+                    data_sharing_consent.granted = True
+                    data_sharing_consent.save()
+
                 try:
                     # Create the Enterprise backend database records for this course enrollment.
                     __, created = EnterpriseCourseEnrollment.objects.get_or_create(


### PR DESCRIPTION
## Description

Right now the Data Sharing Consent option 'Externally Managed' for an enterprise customer does not create the DSC records automatically, we need to change this by creating this record when that option is selected. This PR aims to perform the DSC record creation when the CourseEnrollment view is being handled.

## Changes made
- Extend the enterprise CourseEnrollment view to create a DSC record after the enrollment is successful. This record is created by using the proxy DSC instance created previously.

## How to test
- Setup enterprise and an enterprise customer where the DSC enforce option is set to 'Managed Externally'.
- Use an enterprrise course enrollment link and enroll into the course. The DSC view should not appear and the DSC consent record must be created successfully.