### PR TITLE
PADV-2996 feat: automatically grant data sharing consent for externally managed…

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1707,6 +1707,16 @@ class CourseEnrollmentView(NonAtomicView):
                     {'user': self.user_id, 'message': error_message},
                 )
             if succeeded:
+                # We've dediced to automatically grant consent if the enterprise has
+                # set the enforce_data_sharing_consent config to EXTERNALLY_MANAGED
+                # since the user has already gone through the consent flow outside
+                # of the platform. We do this during the course enrollment process
+                # insde this course enrollment view. This way we can link the consent
+                # to the enterprise customer, course and user.
+                if enterprise_customer.enforce_data_sharing_consent == enterprise_customer.EXTERNALLY_MANAGED:
+                    data_sharing_consent.granted = True
+                    data_sharing_consent.save()
+
                 try:
                     # Create the Enterprise backend database records for this course enrollment.
                     __, created = EnterpriseCourseEnrollment.objects.get_or_create(


### PR DESCRIPTION
## Description

This PR add a custom change to automatically create data sharing consent records for enterprise enrollments, as part of the effort to migrate edx-platfrom to Ulmo Open Edx version.

## Changes

### Related PR

https://github.com/Pearson-Advance/edx-enterprise/pull/16

## Hot to test

- Setup enterprise and an enterprise customer where the DSC enforce option is set to 'Managed Externally'.
- Use an enterprise course enrollment link and enroll into the course. The DSC view should not appear, and the DSC consent record must be created successfully.

## Ticket

https://pearson.atlassian.net/browse/PADV-2996
 