### PR TITLE
PADV-2993 - cherry-pick allow to send key values as query params.

### DIFF
--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -104,6 +104,12 @@ class CourseCatalogApiClient(UserAPIClient):
         Return results from the discovery service's search/all endpoint.
         """
         api_url = self.get_api_url(self.SEARCH_ALL_ENDPOINT)
+
+        # This change allows the key list to be sent as query parameters.
+        # This is a temporary change to support catalogues with specific courses.
+        if content_filter_query.get('key'):
+            query_params['key'] = content_filter_query.get('key')
+
         response = self.client.post(api_url, data=content_filter_query, params=query_params)
         response.raise_for_status()
         response = response.json()


### PR DESCRIPTION
## Ticket

https://pearson.atlassian.net/browse/PADV-2993

## Description

This PR adds cherry-pick commit from pearson-release/olive.main:

- https://github.com/Pearson-Advance/edx-enterprise/pull/12/changes/496036da055dc54b15467bb7de55efd5ff2a9308 This change allows to convert catalogue query "key" values into URL query params.