### PR TITLE
Cherry picking serializers changes

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1377,7 +1377,8 @@ class EnterpriseCustomerCourseEnrollmentsSerializer(serializers.Serializer):
         choices=(
             ('audit', 'audit'),
             ('verified', 'verified'),
-            ('professional', 'professional')
+            ('professional', 'professional'),
+            ('no-id-professional', 'no-id-professional')
         ),
         required=True,
         write_only=True,


### PR DESCRIPTION
## Description

This PR aims to cherry-pick a serializer custom change that allows enrolling users in 'no-id-professional' course mode using the enterprise course enrollment API endpoint.

## PRs related

- https://github.com/Pearson-Advance/edx-enterprise/pull/13