### PR TITLE
fix: allowing external DSC creation during premium flows

### DIFF
--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -1713,6 +1713,28 @@ class CourseEnrollmentView(NonAtomicView):
             enterprise_customer.uuid,
             course_id=course_id
         ).consent_required()
+        # We've decided to automatically grant consent if the enterprise has
+        # set the enforce_data_sharing_consent config to EXTERNALLY_MANAGED
+        # since the user has already gone through the consent flow outside
+        # of the platform. We do this during the course enrollment process
+        # inside this course enrollment view. This way we can link the consent
+        # to the enterprise customer, course and user.
+        # The DSC record will be created for any course mode if the enterprise
+        # has set enforce_data_sharing_consent to EXTERNALLY_MANAGED, since this
+        # option indicates that the user has gone through the consent process
+        # outside of the platform for all courses inside the catalog.
+        if enterprise_customer.enforce_data_sharing_consent == enterprise_customer.EXTERNALLY_MANAGED:
+            data_sharing_consent.granted = True
+            data_sharing_consent.save(update_fields=['granted'])
+            LOGGER.info(
+                '[ENTERPRISE ENROLLMENT PAGE] Automatically granting data sharing consent since enterprise has set '
+                'enforce_data_sharing_consent to EXTERNALLY_MANAGED. Course: [%s], Username: [%s], Enterprise: [%s]',
+                course_id,
+                enterprise_customer_user.username,
+                enterprise_customer.name,
+            )
+            user_consent_needed = False
+
         if not selected_course_mode.get('premium') and not user_consent_needed:
             # For the audit course modes (audit, honor), where DSC is not
             # required, enroll the learner directly through enrollment API
@@ -1739,16 +1761,6 @@ class CourseEnrollmentView(NonAtomicView):
                     {'user': self.user_id, 'message': error_message},
                 )
             if succeeded:
-                # We've dediced to automatically grant consent if the enterprise has
-                # set the enforce_data_sharing_consent config to EXTERNALLY_MANAGED
-                # since the user has already gone through the consent flow outside
-                # of the platform. We do this during the course enrollment process
-                # insde this course enrollment view. This way we can link the consent
-                # to the enterprise customer, course and user.
-                if enterprise_customer.enforce_data_sharing_consent == enterprise_customer.EXTERNALLY_MANAGED:
-                    data_sharing_consent.granted = True
-                    data_sharing_consent.save()
-
                 try:
                     # Create the Enterprise backend database records for this course enrollment.
                     __, created = EnterpriseCourseEnrollment.objects.get_or_create(


### PR DESCRIPTION
## Description

This PR aims to fix scenarios where the DSC record was not being created when is set to 'Externally Managed'. This PR is related to https://github.com/Pearson-Advance/edx-enterprise/pull/16. The issue occurred when a course was set as a 'premium flow', this means that the user should be redirected to a checkout/free basket page in order to complete the enrollment. Previously, the DSC was only being created when the course had no premium flow.

It's important to note that this change would create a DSC record for the user and course for all course modes when the externally managed option is selected. From a business point of view, this option implies that the user already signed a Data sharing consent outside of our platform, and no other consent would be required in any other course mode.

## Changes applied

- Moved logic to check 'externally managed' option and DSC creation so that it covers all course enrollment cases.

## How to test

1. Configure enterprise and enterprise catalog (no enterprise learner portal).
2. Create an enterprise customer with a catalog containing paid and non-paid courses.
3. Setup the setting 'Data sharing consent' to 'Externally Managed'
4. Get enrollment link for course.
5. In another browser session, go to the enrollment link and login as a student.
6. Click enroll button.
7. The DSC record should be created for both premium and regular flow.